### PR TITLE
Group peers by screen number

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,7 +271,14 @@ function handleServerMessage(data) {
             break;
             
         case 'screensList':
-            connectedScreensList = new Map(data.screens);
+            connectedScreensList = new Map();
+            data.screens.forEach(([num, info]) => {
+                const infos = Array.isArray(info) ? info : [info];
+                if (!connectedScreensList.has(num)) {
+                    connectedScreensList.set(num, []);
+                }
+                connectedScreensList.get(num).push(...infos);
+            });
             updateScreenGrid();
             break;
             
@@ -658,23 +665,14 @@ function cleanupOverlays() {
 function updateScreenGrid() {
     const screenGrid = document.getElementById('screenGrid');
     if (!screenGrid) return;
-    
+
     screenGrid.innerHTML = '';
-    
-    // Group clients by screen number
-    const screenGroups = new Map();
-    connectedScreensList.forEach((screenInfo, screenNumber) => {
-        if (!screenGroups.has(screenNumber)) {
-            screenGroups.set(screenNumber, { online: false, clients: [] });
-        }
-        screenGroups.get(screenNumber).clients.push(screenInfo);
-        if (screenInfo.online) {
-            screenGroups.get(screenNumber).online = true;
-        }
-    });
-    
-    // Create cards for each screen
-    screenGroups.forEach((screenData, screenNumber) => {
+
+    // Iterate over screen arrays
+    connectedScreensList.forEach((screenInfos, screenNumber) => {
+        const screenOnline = screenInfos.some(info => info.online);
+        const screenData = { online: screenOnline, clients: screenInfos };
+
         const card = document.createElement('div');
         card.className = `screen-card ${screenData.online ? 'online' : 'offline'}`;
         

--- a/server.js
+++ b/server.js
@@ -317,15 +317,17 @@ function broadcastScreensList() {
     
     const screensList = [];
     registeredScreens.forEach((clientIds, screenNumber) => {
+        const infoList = [];
         clientIds.forEach(clientId => {
             const client = clients.get(clientId);
-            screensList.push([screenNumber, {
+            infoList.push({
                 online: client && client.ws.readyState === WebSocket.OPEN,
                 clientId: clientId
-            }]);
+            });
         });
+        screensList.push([screenNumber, infoList]);
     });
-    
+
     seed.ws.send(JSON.stringify({
         type: 'screensList',
         screens: screensList


### PR DESCRIPTION
## Summary
- parse `screensList` into a `Map<number, ScreenInfo[]>`
- iterate over grouped arrays when populating the screen grid
- send grouped screen info arrays from server

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68531963d310832996f020290a17714c